### PR TITLE
Support transitions without payload in single-payload FSM variant

### DIFF
--- a/Generator/SourceGenerators/ExtensionsVariantGenerator.cs
+++ b/Generator/SourceGenerators/ExtensionsVariantGenerator.cs
@@ -328,7 +328,7 @@ internal sealed class ExtensionsVariantGenerator(StateMachineModel model) : Stat
         string stateTypeForUsage,
         string triggerTypeForUsage)
     {
-        Sb.AppendLine($"var {HookVarContext} = new StateMachineContext<{stateTypeForUsage}, {triggerTypeForUsage}>(");
+        Sb.AppendLine($"var {HookVarContext_Pre} = new StateMachineContext<{stateTypeForUsage}, {triggerTypeForUsage}>(");
         using (Sb.Indent())
         {
             Sb.AppendLine("Guid.NewGuid().ToString(),");
@@ -338,7 +338,7 @@ internal sealed class ExtensionsVariantGenerator(StateMachineModel model) : Stat
             Sb.AppendLine($"{PayloadVar});");
         }
         Sb.AppendLine();
-        Sb.AppendLine($"_extensionRunner.RunBeforeTransition(_extensions, {HookVarContext});");
+        Sb.AppendLine($"_extensionRunner.RunBeforeTransition(_extensions, {HookVarContext_Pre});");
         Sb.AppendLine();
     }
 
@@ -347,7 +347,17 @@ internal sealed class ExtensionsVariantGenerator(StateMachineModel model) : Stat
         string stateTypeForUsage,
         string triggerTypeForUsage)
     {
-        Sb.AppendLine($"_extensionRunner.RunGuardEvaluation(_extensions, {HookVarContext}, \"{transition.GuardMethod}\");");
+        Sb.AppendLine($"var {HookVarContext_Guard} = new StateMachineContext<{stateTypeForUsage}, {triggerTypeForUsage}>(");
+        using (Sb.Indent())
+        {
+            Sb.AppendLine("Guid.NewGuid().ToString(),");
+            Sb.AppendLine($"{CurrentStateField},");
+            Sb.AppendLine("trigger,");
+            Sb.AppendLine($"{stateTypeForUsage}.{TypeHelper.EscapeIdentifier(transition.ToState)},");
+            Sb.AppendLine($"{PayloadVar});");
+        }
+        Sb.AppendLine();
+        Sb.AppendLine($"_extensionRunner.RunGuardEvaluation(_extensions, {HookVarContext_Guard}, \"{transition.GuardMethod}\");");
         Sb.AppendLine();
     }
 
@@ -357,7 +367,7 @@ internal sealed class ExtensionsVariantGenerator(StateMachineModel model) : Stat
         string stateTypeForUsage,
         string triggerTypeForUsage)
     {
-        Sb.AppendLine($"_extensionRunner.RunGuardEvaluated(_extensions, {HookVarContext}, \"{transition.GuardMethod}\", {guardResultVar});");
+        Sb.AppendLine($"_extensionRunner.RunGuardEvaluated(_extensions, {HookVarContext_Guard}, \"{transition.GuardMethod}\", {guardResultVar});");
         Sb.AppendLine();
     }
 
@@ -367,7 +377,7 @@ internal sealed class ExtensionsVariantGenerator(StateMachineModel model) : Stat
         string triggerTypeForUsage,
         bool success)
     {
-        Sb.AppendLine($"_extensionRunner.RunAfterTransition(_extensions, {HookVarContext}, {success.ToString().ToLower()});");
+        Sb.AppendLine($"_extensionRunner.RunAfterTransition(_extensions, {HookVarContext_Pre}, {success.ToString().ToLower()});");
     }
 
     protected override void WriteTransitionFailureHook(

--- a/Generator/SourceGenerators/FullVariantGenerator.cs
+++ b/Generator/SourceGenerators/FullVariantGenerator.cs
@@ -134,7 +134,7 @@ internal sealed class FullVariantGenerator(StateMachineModel model) : PayloadVar
         string stateTypeForUsage,
         string triggerTypeForUsage)
     {
-        Sb.AppendLine($"var {HookVarContext} = new StateMachineContext<{stateTypeForUsage}, {triggerTypeForUsage}>(");
+        Sb.AppendLine($"var {HookVarContext_Pre} = new StateMachineContext<{stateTypeForUsage}, {triggerTypeForUsage}>(");
         using (Sb.Indent())
         {
             Sb.AppendLine("Guid.NewGuid().ToString(),");
@@ -144,7 +144,7 @@ internal sealed class FullVariantGenerator(StateMachineModel model) : PayloadVar
             Sb.AppendLine($"{PayloadVar});");
         }
         Sb.AppendLine();
-        Sb.AppendLine($"_extensionRunner.RunBeforeTransition(_extensions, {HookVarContext});");
+        Sb.AppendLine($"_extensionRunner.RunBeforeTransition(_extensions, {HookVarContext_Pre});");
         Sb.AppendLine();
     }
 
@@ -153,7 +153,17 @@ internal sealed class FullVariantGenerator(StateMachineModel model) : PayloadVar
         string stateTypeForUsage,
         string triggerTypeForUsage)
     {
-        Sb.AppendLine($"_extensionRunner.RunGuardEvaluation(_extensions, {HookVarContext}, \"{transition.GuardMethod}\");");
+        Sb.AppendLine($"var {HookVarContext_Guard} = new StateMachineContext<{stateTypeForUsage}, {triggerTypeForUsage}>(");
+        using (Sb.Indent())
+        {
+            Sb.AppendLine("Guid.NewGuid().ToString(),");
+            Sb.AppendLine($"{CurrentStateField},");
+            Sb.AppendLine("trigger,");
+            Sb.AppendLine($"{stateTypeForUsage}.{TypeHelper.EscapeIdentifier(transition.ToState)},");
+            Sb.AppendLine($"{PayloadVar});");
+        }
+        Sb.AppendLine();
+        Sb.AppendLine($"_extensionRunner.RunGuardEvaluation(_extensions, {HookVarContext_Guard}, \"{transition.GuardMethod}\");");
         Sb.AppendLine();
     }
 
@@ -163,7 +173,7 @@ internal sealed class FullVariantGenerator(StateMachineModel model) : PayloadVar
         string stateTypeForUsage,
         string triggerTypeForUsage)
     {
-        Sb.AppendLine($"_extensionRunner.RunGuardEvaluated(_extensions, {HookVarContext}, \"{transition.GuardMethod}\", {guardResultVar});");
+        Sb.AppendLine($"_extensionRunner.RunGuardEvaluated(_extensions, {HookVarContext_Guard}, \"{transition.GuardMethod}\", {guardResultVar});");
         Sb.AppendLine();
     }
 
@@ -173,7 +183,7 @@ internal sealed class FullVariantGenerator(StateMachineModel model) : PayloadVar
         string triggerTypeForUsage,
         bool success)
     {
-        Sb.AppendLine($"_extensionRunner.RunAfterTransition(_extensions, {HookVarContext}, {success.ToString().ToLower()});");
+        Sb.AppendLine($"_extensionRunner.RunAfterTransition(_extensions, {HookVarContext_Pre}, {success.ToString().ToLower()});");
     }
 
     protected override void WriteTransitionFailureHook(

--- a/Generator/SourceGenerators/StateMachineCodeGenerator.cs
+++ b/Generator/SourceGenerators/StateMachineCodeGenerator.cs
@@ -32,7 +32,10 @@ public abstract class StateMachineCodeGenerator(StateMachineModel model)
     protected HashSet<string> AddedUsings = [];
 
     // Hook variable names
-    protected const string HookVarContext = "smCtx";
+    protected const string HookVarContext_Pre = "smCtx";
+    protected const string HookVarContext_Guard = "smCtxG";
+    protected const string HookVarContext_Post = "smCtxP";
+    protected const string HookVarContext_Error = "smCtxE";
     protected const string EndOfTryFireLabel = "END_TRY_FIRE";
     #endregion
 


### PR DESCRIPTION
## Summary
- allow no-payload firing for single payload variant
- add helper that skips callbacks needing payload but uses parameterless ones
- integrate helper into transition flow
- use distinct context variables for before/guard hooks to avoid naming collisions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e038b00c48326b0727b80cea3f1b0